### PR TITLE
Add non-generic Option class and type infered Option.Some

### DIFF
--- a/Galaxus.Functional.Tests/(Option)/OptionExtensions/NonGenericOptionTests.cs
+++ b/Galaxus.Functional.Tests/(Option)/OptionExtensions/NonGenericOptionTests.cs
@@ -1,0 +1,46 @@
+﻿using NUnit.Framework;
+
+namespace Galaxus.Functional.Tests.OptionExtensions
+{
+    [TestFixture]
+    public class NonGenericOptionTests
+    {
+        [Test]
+        public void From_NullValue_ReturnsNone()
+        {
+            var value = (string) null;
+            var option = Option.From(value);
+
+            Assert.IsTrue(option.IsNone);
+        }
+
+        [Test]
+        public void From_NullableValue_ReturnsNone()
+        {
+            var value = (bool?) null;
+            var option = Option.From(value);
+
+            Assert.IsTrue(option.IsNone);
+        }
+
+        [Test]
+        public void From_Value_ReturnsSome()
+        {
+            var value = "test";
+            var option = Option.From(value);
+
+            Assert.IsTrue(option.IsSome);
+            Assert.AreEqual("test", option.Unwrap());
+        }
+
+        [Test]
+        public void From_NullableValue_ReturnsSome()
+        {
+            var value = (bool?) true;
+            var option = Option.From(value);
+
+            Assert.IsTrue(option.IsSome);
+            Assert.AreEqual(true, option.Unwrap());
+        }
+    }
+}

--- a/Galaxus.Functional/(Option)/Option.cs
+++ b/Galaxus.Functional/(Option)/Option.cs
@@ -259,4 +259,18 @@ namespace Galaxus.Functional
 
         #endregion
     }
+
+    /// <summary>
+    /// A class adding type inference functionality to <see cref="Option{T}"/>
+    /// </summary>
+    public sealed class Option
+    {
+        /// <summary>
+        ///     Creates an <see cref="Option{T}" /> instance containing a value
+        /// </summary>
+        /// <typeparam name="T">The type of the contained value</typeparam>
+        /// <param name="value">The value to be contained inside the <see cref="Option{T}" /></param>
+        /// <returns>An <see cref="Option{T}" /></returns>
+        public static Option<T> Some<T>(T value) => Option<T>.Some(value);
+    }
 }

--- a/Galaxus.Functional/(Option)/Option.cs
+++ b/Galaxus.Functional/(Option)/Option.cs
@@ -272,5 +272,23 @@ namespace Galaxus.Functional
         /// <param name="value">The value to be contained inside the <see cref="Option{T}" /></param>
         /// <returns>An <see cref="Option{T}" /></returns>
         public static Option<T> Some<T>(T value) => Option<T>.Some(value);
+
+        /// <summary>
+        ///     Creates an instance of <see cref="Option{T}" /> which either contains the value specified or is
+        ///     <see cref="Option{T}.None" />
+        /// </summary>
+        /// <typeparam name="T">The type of the possibly contained value</typeparam>
+        /// <param name="value">The possible value inside the <see cref="Option{T}" /></param>
+        /// <returns>
+        ///     Either <see cref="Option{T}.Some" /> with the value specified, or <see cref="Option{T}.None" /> if
+        ///     null was supplied
+        /// </returns>
+        public static Option<T> From<T>(T value)
+        {
+            if (value == null)
+                return Option<T>.None;
+
+            return Some(value);
+        }
     }
 }


### PR DESCRIPTION
This commit adds a non-generic sealed Option class to the same namespace as the generic Option struct that aids in creation through type inference